### PR TITLE
Unlicense default config

### DIFF
--- a/.crossref-verifier.yaml
+++ b/.crossref-verifier.yaml
@@ -1,3 +1,9 @@
+<!--
+   - SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+   -
+   - SPDX-License-Identifier: Unlicense
+   -->
+
 # Parameters of repository traversal.
 traversal:
   # Folders which we pretend do not exist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,22 +30,17 @@ checkmark indicating that you are sure it is dealt with (be that by irrelevance)
   - [ ] If I fixed a bug, I added a regression test to prevent the bug from
         silently reappearing again.
 
-[//]: # (Add more docs here if you have them in the repository)
 - Documentation
   - [ ] I checked whether I should update the docs and did so if necessary:
     - [README](/README.md)
     - Haddock
 
-[//]: # (Mostly for public repositories)
-[//]: # (Recording changes is optional, depends on repository, useful for some libs)
 - Public contracts
   - [ ] Any modifications of public contracts comply with the [Evolution
   of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
   - [ ] provided a migration guide for breaking changes if possible
 
 #### Stylistic guide (mandatory)
-
-[//]: # (Update link to style guide if necesary or remove if it's not present)
 
 - [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
 - [ ] My code complies with the [style guide](docs/code-style.md).


### PR DESCRIPTION
## Description

Problem: default config is not really smart and seems easier to just
unlicense it, i. e. let everyone do whatever they want with it.
Also it does not have SPDX header (like any other file in this repo,
but that's another story).

Solution: add SPDX header stating that the Unlicense applies.
Make Serokell copyright holder of it, AFAIK @martoon is fine with
that (and I am not sure whether copyright holder matters for
unlicensed files at all).

## Related issue(s)

That's for a private project.

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
