### PR TITLE
Build binary by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
-result*/
+result
+result-*

--- a/default.nix
+++ b/default.nix
@@ -17,4 +17,4 @@ in (hn.stackProject {
     url = "https://github.com/${lootbox.owner}/${lootbox.repo}.git";
     subdir = "code/prelude";
   }];
-}).crossref-verifier
+}).crossref-verifier.components.exes

--- a/default.nix
+++ b/default.nix
@@ -2,19 +2,21 @@ let
   sources = import ./nix/sources.nix;
   nixpkgs = import sources.nixpkgs (import sources."haskell.nix");
   hn = nixpkgs.haskell-nix;
-in (hn.stackProject {
-  src = hn.haskellLib.cleanGit { src = ./.; };
-  modules = [{
-    packages.crossref-verifier = {
-      # More failures during CI == Less failures in runtime!
-      postHaddock = ''[[ -z "$(ls -A dist/doc/html)" ]] && exit 1 || echo "haddock successfully generated documentation"'';
-      package.ghcOptions = "-Werror";
-    };
-  }];
-  cache = with sources; [{
-    name = "loot-prelude";
-    inherit (lootbox) sha256 rev;
-    url = "https://github.com/${lootbox.owner}/${lootbox.repo}.git";
-    subdir = "code/prelude";
-  }];
-}).crossref-verifier.components.exes
+  project = hn.stackProject {
+    src = hn.haskellLib.cleanGit { src = ./.; };
+    modules = [{
+      packages.crossref-verifier = {
+        # More failures during CI == Less failures in runtime!
+        postHaddock = ''
+          [[ -z "$(ls -A dist/doc/html)" ]] && exit 1 || echo "haddock successfully generated documentation"'';
+        package.ghcOptions = "-Werror";
+      };
+    }];
+    cache = with sources; [{
+      name = "loot-prelude";
+      inherit (lootbox) sha256 rev;
+      url = "https://github.com/${lootbox.owner}/${lootbox.repo}.git";
+      subdir = "code/prelude";
+    }];
+  };
+in with project; [ crossref-verifier.components.exes crossref-verifier ]

--- a/package.yaml
+++ b/package.yaml
@@ -95,6 +95,7 @@ executables:
     - -O2
     dependencies:
     - crossref-verifier
+    - yaml
 
 tests:
   crossref-verifier-tests:

--- a/package.yaml
+++ b/package.yaml
@@ -95,7 +95,6 @@ executables:
     - -O2
     dependencies:
     - crossref-verifier
-    - yaml
 
 tests:
   crossref-verifier-tests:


### PR DESCRIPTION
## Description

Build binary instead of a library so that the old `nix run -f <crossref-verifier> -c crossref-verifier` approach on CI's works.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
