### PR TITLE
Add issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Reporting issues
 
-Please [open an issue](../../../issues) if you find a bug or have a feature request.
+Please [open an issue](../../../issues/new/choose) if you find a bug or have a feature request.
 Note: you need to login (e. g. using your GitHub account) first.
 Before submitting a bug report or feature request, check to make sure it hasn't already been submitted
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: If you think our software behaves not the way it should, report a bug
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+---
+
+# Description
+
+<!--
+A clear and concise description of what the bug is.
+-->
+
+# To Reproduce
+
+Steps to reproduce the behavior:
+<!--
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+# Expected behavior
+
+<!--
+A clear and concise description of what you expected to happen.
+-->
+
+# Environment
+
+- OS
+- branch/revision
+
+# Additional context
+
+<!--
+Add any other context about the problem here.
+-->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,20 @@
+---
+name: Task
+about: Suggest a task for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Clarification and motivation
+
+<!--
+Clarify what you want to be done and why.
+-->
+
+# Acceptance criteria
+
+<!--
+Clarify how we can verify that the task is done.
+-->


### PR DESCRIPTION
## Description

Problem: by default, when creating an issue, user has to fill everything
from scratch and this is not good.

Solution: add issue templates for `task` and `bug`, refer people to
page for openning new issue in `CONTRIBUTING.md`.

Addresses [this comment](https://github.com/serokell/crossref-verifier/pull/6#issuecomment-562537893).

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
