### PR TITLE
default.nix: return a derivation instead of a set

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,1 @@
-(import ./crossref-verifier.nix).components.exes
+(import ./crossref-verifier.nix).components.exes.crossref-verify


### PR DESCRIPTION
`default.nix` was returning a set with a single derivation instead of a derivation. It works with `nix run` and `nix-build`, because they traverse all values in a set, but doesn't allow to use the package in places where a derivation is expected.