### PR TITLE
[INT-111] Allow to build crossref-verify statically

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,16 @@
 
 steps:
   - command: nix-build crossref-verifier.nix
-    label: build everything
+    label: Library and tests
+  - command: nix-build
+    label: Executable
+    artifact_paths:
+      - "result/bin/crossref-verify"
   - command: nix run -f. -c crossref-verify
-    label: crossref-verify itself (import as if done externally)
+    label: Crossref-verify itself
   - command: nix run -f $(nix eval -f nix/sources.nix --raw nixpkgs) reuse -c reuse lint
-    label: reuse lint
+    label: REUSE lint
+  - command:
+      - GITHUB_TOKEN=$(cat ~/niv-bot-token) NIX_PATH=nixpkgs=$(nix eval --raw '(import ./nix/sources.nix).nixpkgs') nix-shell -p curl git gitAndTools.hub --run "curl https://raw.githubusercontent.com/serokell/scratch/release-binary/scripts/release-binary.sh | bash"
+    label: Create a pre-release
+    branches: master

--- a/crossref-verifier.nix
+++ b/crossref-verifier.nix
@@ -6,7 +6,10 @@
 let
   sources = import ./nix/sources.nix;
   nixpkgs = import sources.nixpkgs (import sources."haskell.nix");
-  hn = if static then nixpkgs.pkgsCross.musl64.haskell-nix else nixpkgs.haskell-nix;
+  hn = if static then
+    nixpkgs.pkgsCross.musl64.haskell-nix
+  else
+    nixpkgs.haskell-nix;
   project = hn.stackProject {
     src = hn.haskellLib.cleanGit { src = ./.; };
     modules = [{

--- a/default.nix
+++ b/default.nix
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-(import ./crossref-verifier.nix).components.exes.crossref-verify
+(import ./crossref-verifier.nix {}).components.exes.crossref-verify

--- a/release/default.nix
+++ b/release/default.nix
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+{ pkgs ? import (import ../nix/sources.nix).nixpkgs { } }:
+let
+  executable = (import ../crossref-verifier.nix {
+    static = true;
+  }).components.exes.crossref-verify;
+  joinByBasename = name: paths:
+    pkgs.runCommandNoCC name { } (''
+      mkdir $out
+    '' + pkgs.lib.concatMapStrings (path: ''
+      ln -s ${path} $out/${builtins.baseNameOf path}
+    '') paths);
+in joinByBasename "crossref-verifier-release" [
+  "${executable}/bin"
+  ../LICENSES
+  ../README.md
+]


### PR DESCRIPTION
## Description

Change `crossref-verifier.nix` and add `static.nix` so that building a fully static executable is possible.

Results look like this:
[crossref-verify.gz](https://github.com/serokell/crossref-verifier/files/3991431/crossref-verify.gz)

It's probably better if someone checks this on multiple distros before we merge.

## Related issue(s)

https://issues.serokell.io/issue/INT-111

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](docs/code-style.md).
